### PR TITLE
Establish repo maintainer via CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TodayTix/mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @TodayTix/mobile
+* @zviehrman-ttg @TodayTix/mobile


### PR DESCRIPTION
#### GitHub Issue

Relates to https://github.com/TodayTix/ttg/pull/16536

#### Problem

No named maintainer for this repo. No clear accountability for PR throughput, review reliability, or CI health.

#### Outcome

Zvi auto-assigned as reviewer on all PRs via CODEOWNERS (advisory, not blocking).

#### Decisions

- CODEOWNERS is advisory only — no branch protection rule requiring code owner approval
- Full ownership model: [repo-maintenance.md](https://github.com/TodayTix/ttg/pull/16536)
- [Repo Ownership Map](https://docs.google.com/spreadsheets/d/1GCTZ13M9skhd7cgHUXgDQ2ePl6AQA2nGCYtaQuhv-0Q/edit)

---

#### Checklist
- [x] PR title formatted for release notes