### PR TITLE
Fix CircleCI release job rejected by invalid xcode 14.2.0 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
   create-new-release:
     working_directory: ~/project
     macos:
-     xcode: 14.2.0 # min macOS version for this is 12.6.3. Possible values at https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
+     xcode: 16.2.0 # Possible values at https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - *restore_gems_cache


### PR DESCRIPTION
## Problem

The `create-new-release` CircleCI job fails before it can run. CircleCI rejects it with:

> Job was rejected because resource class m4pro.medium, image xcode:14.2.0 is not a valid resource class

This blocks automated releases of the design tokens.

## Outcome

The release job runs on a currently-supported macOS executor, matching the main iOS repo's setup.

## Context

The job used `xcode: 14.2.0` with the implicit (now-deprecated Intel) resource class. CircleCI no longer offers that image/resource-class combination. The main iOS repo ([TodayTix/iOS](https://github.com/TodayTix/iOS)) runs `xcode 16.2.0` on `macos.m1.medium.gen1`.

## What changed

`.circleci/config.yml` — `create-new-release` job now pins:
- `xcode: 16.2.0`
- `resource_class: macos.m1.medium.gen1`

## How to verify

Trigger the `new-version` workflow on `main` (runs on push to `main`) and confirm the `create-new-release` job is accepted and starts, rather than being rejected at queue time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)